### PR TITLE
feat: 支持 --hw-cntr 控制头文件与 HardwareContainer生成，完善 CMake 清理逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Parses `.ioc` files and creates `.config.yaml` with a readable summary.
 Generates STM32 application code from YAML.
 
 ```bash
-usage: xr_gen_code_stm32 [-h] -i INPUT -o OUTPUT [--xrobot] [--libxr-config LIBXR_CONFIG]
+usage: xr_gen_code_stm32 [-h] -i INPUT -o OUTPUT [--xrobot] [--hw-cntr] [--libxr-config LIBXR_CONFIG]
 ```
 
 #### 🔧 Required
@@ -219,6 +219,10 @@ usage: xr_gen_code_stm32 [-h] -i INPUT -o OUTPUT [--xrobot] [--libxr-config LIBX
 
   启用 XRobot glue 代码生成  
   Enable XRobot glue generation
+
+- `--hw-cntr`  
+  生成 LibXR HardwareContainer 定义及 app_framework.hpp 头文件（可用于非 XRobot 项目）  
+  Generate LibXR HardwareContainer definition and include app_framework.hpp header (can be used without XRobot)
 
 - `--libxr-config`：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libxr"
-version = "0.4.1"
+version = "0.4.2"
 description = "C++ code generator for LibXR-based embedded systems, supporting STM32 and modular robotics applications."
 requires-python = ">=3.8"
 authors = [

--- a/src/libxr/GeneratorSTM32CMake.py
+++ b/src/libxr/GeneratorSTM32CMake.py
@@ -67,6 +67,17 @@ endif()
 
 include_cmake_cmd = "include(${CMAKE_CURRENT_LIST_DIR}/cmake/LibXR.CMake)\n"
 
+def clean_cmake_build_dirs(input_directory):
+    removed = False
+    for d in os.listdir(input_directory):
+        full_path = os.path.join(input_directory, d)
+        if os.path.isdir(full_path) and (d == "build" or d.startswith("cmake-build")):
+            logging.info(f"Removing build directory: {full_path}")
+            shutil.rmtree(full_path)
+            removed = True
+    if not removed:
+        logging.info("No build or cmake-build* directory found, nothing to clean.")
+
 def main():
     from libxr.PackageInfo import LibXRPackageInfo
 
@@ -82,11 +93,7 @@ def main():
         logging.error("Input directory does not exist.")
         exit(1)
 
-    build_path = os.path.join(input_directory, "build")
-    if os.path.exists(build_path) and os.path.isdir(build_path):
-        logging.info("Removing existing 'build' directory...")
-        shutil.rmtree(build_path)
-        logging.info("'build' directory removed.")
+    clean_cmake_build_dirs(input_directory)
 
     file_path = os.path.join(input_directory, "cmake", "LibXR.CMake")
 


### PR DESCRIPTION
- xr_gen_code_stm32 新增 --hw-cntr 参数，可独立控制 HardwareContainer 与 app_framework 头文件生成。
- xr_stm32_cmake 增加 clean_cmake_build_dirs，自动删除 build 和 cmake-build* 目录，适配 CLion/CMake 多平台。