### PR TITLE
废弃 Clang 工具链生成脚本及参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Generates platform-agnostic C++ hardware abstraction code from YAML.
 Automatically configures an STM32CubeMX project.
 
 ```bash
-usage: xr_cubemx_cfg [-h] -d DIRECTORY [-t TERMINAL] [-c] [--xrobot]
+usage: xr_cubemx_cfg [-h] -d DIRECTORY [-t TERMINAL] [--xrobot]
 ```
 
 解析 `.ioc` 文件，生成 YAML 和 C++ 驱动代码，补丁中断处理函数，并初始化项目结构  
@@ -122,8 +122,8 @@ Parses `.ioc`, generates YAML and C++ code, patches interrupt handlers, and init
 
 - `-c, --clang`：
 
-  启用 Clang 构建支持  
-  Enable Clang build support.
+  启用 Clang 构建支持 (此选项已经弃用) 
+  Enable Clang build support. (This option has been deprecated) 
 
 - `--xrobot`：
 
@@ -354,6 +354,12 @@ Creates Clang-compatible toolchain file.
 ```bash
 usage: xr_stm32_clang [-h] input_dir
 ```
+
+#### 工具已弃用 / Deprecated Notice
+
+自 STM32CubeMX 15.0 起，官方已原生支持 Clang 工具链，并会自动生成 starm-clang.cmake 文件。
+
+Since STM32CubeMX 15.0, native Clang support is provided and starm-clang.cmake will be generated automatically.
 
 #### 🔧 必选参数 (Required)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libxr"
-version = "0.4.2"
+version = "0.4.3"
 description = "C++ code generator for LibXR-based embedded systems, supporting STM32 and modular robotics applications."
 requires-python = ">=3.8"
 authors = [

--- a/src/libxr/GeneratorSTM32CMakeClang.py
+++ b/src/libxr/GeneratorSTM32CMakeClang.py
@@ -5,6 +5,7 @@ import sys
 
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
+
 def find_toolchain_file(directory):
     """
     Searches for gcc-arm-none-eabi.cmake in the specified directory.
@@ -13,9 +14,7 @@ def find_toolchain_file(directory):
     """
     if not os.path.isdir(directory):
         logging.error(
-            f"The specified directory '{directory}' does not exist or is invalid.",
-            file=sys.stderr,
-        )
+            f"The specified directory '{directory}' does not exist or is invalid.")
         return None
 
     target_filename = "gcc-arm-none-eabi.cmake"
@@ -55,10 +54,10 @@ def parse_cmake_file(file_path):
                     )
 
     except FileNotFoundError:
-        logging.error(f"CMake file '{file_path}' not found.", file=sys.stderr)
+        logging.error(f"CMake file '{file_path}' not found.")
         sys.exit(1)
     except Exception as e:
-        logging.error(f"Failed to parse the CMake file - {e}", file=sys.stderr)
+        logging.error(f"Failed to parse the CMake file - {e}")
         sys.exit(1)
 
     return data
@@ -204,6 +203,11 @@ def main():
 
     LibXRPackageInfo.check_and_print()
 
+    logging.warning(
+        "This tool is deprecated since STM32CubeMX 15.0. Native Clang support is provided by CubeMX. "
+        "You probably do NOT need to run this script."
+    )
+
     parser = argparse.ArgumentParser(
         description="Parse the CMake configuration file and extract key data. Overwrites the original file by default."
     )
@@ -223,10 +227,14 @@ def main():
     toolchain_file = find_toolchain_file(args.input_dir)
     if not toolchain_file:
         logging.error(
-            f"Could not find 'gcc-arm-none-eabi.cmake' in '{args.input_dir}/cmake'.",
-            file=sys.stderr,
+            f"Could not find 'gcc-arm-none-eabi.cmake' in '{args.input_dir}/cmake'."
         )
         sys.exit(1)
+
+    starm_clang_cmake = os.path.join(args.input_dir, "cmake", "starm-clang.cmake")
+    if os.path.exists(starm_clang_cmake):
+        logging.info("Detected 'starm-clang.cmake' (CubeMX 15.0+). No action needed.")
+        sys.exit(0)
 
     cmake_file_path = os.path.join(os.path.abspath(args.input_dir), "CMakeLists.txt")
 
@@ -252,8 +260,7 @@ def main():
     linker_script_path = os.path.join(args.input_dir, data["linker_script"])
     if not os.path.exists(linker_script_path):
         logging.error(
-            f"Linker script '{data['linker_script']}' not found.",
-            file=sys.stderr,
+            f"Linker script '{data['linker_script']}' not found."
         )
         sys.exit(-1)
 
@@ -276,7 +283,7 @@ def main():
             cmake_file_lines = out_file.readlines()
     except Exception as e:
         logging.error(
-            f"Failed to write to file '{cmake_file_path}' - {e}", file=sys.stderr
+            f"Failed to write to file '{cmake_file_path}' - {e}"
         )
         sys.exit(1)
 


### PR DESCRIPTION
- 将 '-c/--clang' 相关参数和文档标注为已弃用
- xr_stm32_clang 工具增加废弃提示，检测 starm-clang.cmake 后自动退出
- README 和命令行帮助同步更新弃用说明
- 版本号更新至 0.4.3