### PR TITLE
[codex] fix stm32 flash layouts and add import smoke

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -141,6 +141,10 @@ jobs:
             pip install $pkg.FullName
           }
 
+      - name: Import smoke check (all top-level modules)
+        run: |
+          python ./scripts/ci_import_smoke.py
+
       - name: Checkout BSP Compatibility Test Repo
         uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libxr"
-version = "5.1.8"
+version = "5.1.9"
 description = "C++ code generator for LibXR-based embedded systems, supporting STM32 and modular robotics applications."
 requires-python = ">=3.8"
 authors = [
@@ -43,4 +43,4 @@ xr_cubemx_cfg = "libxr.ConfigCubemxProject:main"
 where = ["src"]
 
 [tool.setuptools.package-data]
-"libxr" = ["libxr_version.py"]
+"libxr" = ["libxr_version.py", "STM32FlashLayoutRules.xml"]

--- a/scripts/ci_import_smoke.py
+++ b/scripts/ci_import_smoke.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Import all top-level libxr modules from the installed package."""
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src" / "libxr"
+
+    failures = []
+    imported = []
+
+    for path in sorted(src_dir.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+
+        module_name = f"libxr.{path.stem}"
+        try:
+            importlib.import_module(module_name)
+            imported.append(module_name)
+        except Exception as error:
+            failures.append((module_name, error))
+
+    print(f"Imported {len(imported)} modules.")
+    for module_name in imported:
+        print(f"OK  {module_name}")
+
+    if failures:
+        print(f"Failed to import {len(failures)} modules.", file=sys.stderr)
+        for module_name, error in failures:
+            print(f"ERR {module_name}: {error}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/libxr/GeneratorSTM32CMake.py
+++ b/src/libxr/GeneratorSTM32CMake.py
@@ -10,7 +10,7 @@ from typing import Union
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
 LIBXR_CMAKE_TEMPLATE = (
-'''set(CMAKE_CXX_STANDARD 17)
+'''set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # LibXR
@@ -20,6 +20,12 @@ set(XROBOT_MODULES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Modules)
 add_subdirectory(Middlewares/Third_Party/LibXR)
 target_link_libraries(xr
     PUBLIC stm32cubemx
+)
+target_compile_features(xr PUBLIC cxx_std_20)
+
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
 )
 
 target_include_directories(xr
@@ -72,29 +78,77 @@ endif()
 include_cmake_cmd = "include(${CMAKE_CURRENT_LIST_DIR}/cmake/LibXR.CMake)\n"
 
 
+def normalize_libxr_cmake(content: str, system: str) -> str:
+    content = re.sub(
+        r'^\s*set\s*\(\s*CMAKE_CXX_STANDARD\s+\d+\s*\)\s*\n?',
+        '',
+        content,
+        flags=re.MULTILINE
+    )
+    content = re.sub(
+        r'^\s*set\s*\(\s*CMAKE_CXX_STANDARD_REQUIRED\s+\S+\s*\)\s*\n?',
+        '',
+        content,
+        flags=re.MULTILINE
+    )
+    content = "set(CMAKE_CXX_STANDARD 20)\nset(CMAKE_CXX_STANDARD_REQUIRED ON)\n\n" + content.lstrip('\n')
+
+    system_pattern = re.compile(
+        r'(^\s*set\s*\(\s*LIBXR_SYSTEM\s+)(\S+)(\s*\)\s*)',
+        re.MULTILINE
+    )
+    if system_pattern.search(content):
+        content = system_pattern.sub(rf'\1{system}\3', content, count=1)
+    else:
+        content = re.sub(
+            r'(^\s*set\s*\(\s*LIBXR_DRIVER\s+\S+\s*\)\s*$)',
+            f"set(LIBXR_SYSTEM {system})\n\\1",
+            content,
+            count=1,
+            flags=re.MULTILINE
+        )
+
+    content = re.sub(
+        r'target_compile_features\s*\(\s*xr\s+PUBLIC\s+cxx_std_\d+\s*\)',
+        'target_compile_features(xr PUBLIC cxx_std_20)',
+        content,
+        count=1
+    )
+    if "target_compile_features(xr PUBLIC cxx_std_20)" not in content:
+        content = re.sub(
+            r'(target_link_libraries\s*\(\s*xr\b[\s\S]*?\)\s*)',
+            r'\1\ntarget_compile_features(xr PUBLIC cxx_std_20)\n',
+            content,
+            count=1
+        )
+
+    if "set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES" not in content:
+        content = re.sub(
+            r'(^\s*target_include_directories\(\$\{CMAKE_PROJECT_NAME\}\s+PRIVATE\s*$)',
+            "set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES\n"
+            "    CXX_STANDARD 20\n"
+            "    CXX_STANDARD_REQUIRED ON\n"
+            ")\n\n"
+            r'\1',
+            content,
+            count=1,
+            flags=re.MULTILINE
+        )
+
+    return content
+
+
 def update_or_create_libxr_cmake(file_path: str, system: str) -> None:
     cmake_path = Path(file_path)
 
     if cmake_path.exists():
         content = read_text_with_fallback(str(cmake_path))
-
-        pattern = re.compile(
-            r'(^\s*set\s*\(\s*LIBXR_SYSTEM\s+)(\S+)(\s*\)\s*)',
-            re.MULTILINE
-        )
-
-        if pattern.search(content):
-            new_content, count = pattern.subn(rf'\1{system}\3', content, count=1)
-            if count > 0 and new_content != content:
-                cmake_path.write_text(new_content, encoding="utf-8")
-                logging.info(f"Updated LIBXR_SYSTEM in existing LibXR.CMake to: {system}")
-            else:
-                logging.info("LIBXR_SYSTEM already up to date, no changes needed.")
-        else:
-            insertion = f"set(LIBXR_SYSTEM {system})\n"
-            new_content = insertion + content
+        new_content = normalize_libxr_cmake(content, system)
+        if new_content != content:
             cmake_path.write_text(new_content, encoding="utf-8")
-            logging.info(f"Inserted LIBXR_SYSTEM into existing LibXR.CMake: {system}")
+            logging.info(f"Updated existing LibXR.CMake for system: {system}")
+        else:
+            logging.info("LibXR.CMake already up to date, no changes needed.")
     else:
         cmake_path.write_text(
             LIBXR_CMAKE_TEMPLATE.replace("_LIBXR_SYSTEM_", system),

--- a/src/libxr/STM32FlashGenerator.py
+++ b/src/libxr/STM32FlashGenerator.py
@@ -1,14 +1,19 @@
 import re
-from dataclasses import dataclass
-from typing import Optional, List
 import sys
 import traceback
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Optional, Pattern, Tuple
+
 import yaml
 
 
 @dataclass
 class FlashSector:
     """Flash memory sector information"""
+
     index: int
     address: int
     size: int
@@ -17,31 +22,79 @@ class FlashSector:
 @dataclass
 class FlashInfo:
     """Complete flash memory configuration"""
+
     model: str
     flash_base: int
     flash_sectors: List[FlashSector]
     flash_size_kb: Optional[int] = None
 
 
+@dataclass(frozen=True)
+class FlashRule:
+    name: str
+    prefix: Optional[str]
+    contains: Optional[str]
+    regex: Optional[Pattern[str]]
+    flash_kb: Optional[int]
+    flash_kb_min: Optional[int]
+    flash_kb_max: Optional[int]
+    layout_type: str
+    size_bytes: Optional[int]
+    pattern_kb: Tuple[int, ...]
+    bank_kb: Optional[int]
+    bank_address_stride_kb: Optional[int]
+
+
 FLASH_SIZE_CODES = {
-    '4': 16, '6': 32, '8': 64, 'B': 128, 'C': 256, 'D': 384,
-    'E': 512, 'F': 768, 'G': 1024, 'H': 1536, 'I': 2048,
-    'J': 3072, 'K': 4096, 'L': 6144, 'M': 8192, 'N': 12288,
-    'P': 16384, 'Q': 512, 'R': 640, 'S': 768, 'T': 1024, 'Z': 512,
-    '5': 512, '7': 2048, 'A': 1024, 'V': 1024, 'W': 512, 'X': 1024, 'Y': 2048,
-    '1': 256, '3': 8,
+    "4": 16,
+    "6": 32,
+    "8": 64,
+    "B": 128,
+    "C": 256,
+    "D": 384,
+    "E": 512,
+    "F": 768,
+    "G": 1024,
+    "H": 1536,
+    "I": 2048,
+    "J": 3072,
+    "K": 4096,
+    "L": 6144,
+    "M": 8192,
+    "N": 12288,
+    "P": 16384,
+    "Q": 512,
+    "R": 640,
+    "S": 768,
+    "T": 1024,
+    "Z": 512,
+    "5": 512,
+    "7": 2048,
+    "A": 1024,
+    "V": 1024,
+    "W": 512,
+    "X": 1024,
+    "Y": 2048,
+    "1": 256,
+    "3": 8,
 }
+
+U5_FLASH_SIZE_CODES = dict(FLASH_SIZE_CODES)
+U5_FLASH_SIZE_CODES["J"] = 4096
+
+_FLASH_BASE = 0x08000000
 
 
 def get_flash_kb(model: str) -> int:
     """Get flash size from STM32 model number (original logic preserved)"""
     model = model.strip().upper()
 
-    # Original condition chain preserved
+    if model.startswith("STM32N6"):
+        raise ValueError("STM32N6 devices do not provide internal user flash")
     if model.startswith("STM32WL"):
         if "X" in model:
             return 1024
-        if any(code in model for code in ['55', '54', '53', '52']):
+        if any(code in model for code in ["55", "54", "53", "52"]):
             return 512
         return 512
     if model.startswith("STM32WBA"):
@@ -54,12 +107,9 @@ def get_flash_kb(model: str) -> int:
             return 1024
         return 512
     if model.startswith("STM32U5"):
-        if "A" in model:
-            return 1024
         code = model[10]
-        return FLASH_SIZE_CODES.get(code, None)
+        return U5_FLASH_SIZE_CODES.get(code, None)
 
-    # Original fallback logic
     try:
         return FLASH_SIZE_CODES[model[10]]
     except (KeyError, IndexError):
@@ -67,76 +117,275 @@ def get_flash_kb(model: str) -> int:
 
 
 def layout_flash(model: str) -> FlashInfo:
-    """Flash layout generator (original logic fully preserved)"""
-    model = model.upper()
+    """Resolve STM32 flash layout from a single XML rule source."""
+    model = model.strip().upper()
     flash_kb = get_flash_kb(model)
-    flash_base = 0x08000000
-    layout = []
 
-    # Original condition chain
-    if "F1" in model:
-        page_size = 1024 if flash_kb <= 128 else 2048
-        layout = [((flash_kb * 1024) // page_size, page_size)]
-    elif "F2" in model or "F4" in model:
-        sector_sizes = [16, 16, 16, 16, 64] + [128] * 12
-        layout = []
-        remaining = flash_kb
-        for size in sector_sizes:
-            if remaining >= size:
-                layout.append((1, size * 1024))
-                remaining -= size
-            else:
-                break
-    elif "U5" in model:
-        layout = [(1, 128 * 1024)] * (flash_kb // 128)
-    elif any(x in model for x in ["WL", "L4", "G0", "G4", "C0", "U0"]):
-        layout = [((flash_kb * 1024) // 2048, 2048)]
-    elif "L0" in model:
-        layout = [((flash_kb * 1024) // 128, 128)]
-    elif "WB" in model:
-        layout = [((flash_kb * 1024) // 4096, 4096)]
-    elif "WBA" in model:
-        layout = [(1, 32 * 1024)] * (flash_kb // 32)
-    elif "H7" in model:
-        layout = [((flash_kb * 1024) // (128 * 1024), 128 * 1024)]
-    elif any(x in model for x in ["F7", "F3", "F0"]):
-        layout = [((flash_kb * 1024) // 2048, 2048)]
-    elif "L1" in model:
-        layout = [((flash_kb * 1024) // 256, 256)]
+    rule = _match_flash_rule(model, flash_kb)
+    if rule is None:
+        sector_entries = _build_contiguous_sector_entries(
+            _build_uniform_sector_sizes(flash_kb, 1024)
+        )
     else:
-        layout = [((flash_kb * 1024) // 1024, 1024)]
+        sector_entries = _build_sector_entries_from_rule(rule, flash_kb)
 
-    # Original sector generation
-    sectors = []
-    addr = flash_base
-    for count, size in layout:
-        for _ in range(count):
-            sectors.append(FlashSector(
-                index=len(sectors),
-                address=addr,
-                size=size
-            ))
-            addr += size
-
-    return FlashInfo(
-        model=model,
-        flash_base=flash_base,
-        flash_sectors=sectors,
-        flash_size_kb=flash_kb
-    )
+    return _build_flash_info(model, flash_kb, sector_entries)
 
 
 def flash_info_to_dict(info: FlashInfo) -> dict:
-    """Original serialization logic preserved"""
     return {
         "model": info.model,
         "flash_base": f"0x{info.flash_base:08X}",
         "flash_size_kb": info.flash_size_kb,
         "sectors": [
-            {"index": s.index, "address": f"0x{s.address:08X}", "size_kb": round(s.size / 1024, 3)}
-            for s in info.flash_sectors
-        ]
+            {
+                "index": sector.index,
+                "address": f"0x{sector.address:08X}",
+                "size_kb": round(sector.size / 1024, 3),
+            }
+            for sector in info.flash_sectors
+        ],
     }
+
+
+def _build_flash_info(
+    model: str,
+    flash_kb: int,
+    sector_entries: List[Tuple[int, int]],
+) -> FlashInfo:
+    sectors = []
+
+    for address, size in sector_entries:
+        sectors.append(
+            FlashSector(
+                index=len(sectors),
+                address=address,
+                size=size,
+            )
+        )
+
+    return FlashInfo(
+        model=model,
+        flash_base=_FLASH_BASE,
+        flash_sectors=sectors,
+        flash_size_kb=flash_kb,
+    )
+
+
+def _build_contiguous_sector_entries(
+    sector_sizes: List[int],
+    start_address: int = _FLASH_BASE,
+) -> List[Tuple[int, int]]:
+    sector_entries = []
+    address = start_address
+
+    for size in sector_sizes:
+        sector_entries.append((address, size))
+        address += size
+
+    return sector_entries
+
+
+def _build_uniform_sector_sizes(flash_kb: int, size_bytes: int) -> List[int]:
+    total_bytes = flash_kb * 1024
+    if total_bytes % size_bytes != 0:
+        raise ValueError(
+            f"Flash size {flash_kb}KB is not divisible by erase size {size_bytes}B"
+        )
+    return [size_bytes] * (total_bytes // size_bytes)
+
+
+def _build_sequence_sector_sizes(flash_kb: int, pattern_kb: Tuple[int, ...]) -> List[int]:
+    remaining_kb = flash_kb
+    sector_sizes = []
+
+    for size_kb in pattern_kb:
+        if remaining_kb < size_kb:
+            break
+        sector_sizes.append(size_kb * 1024)
+        remaining_kb -= size_kb
+
+    if remaining_kb != 0:
+        raise ValueError(
+            f"Flash size {flash_kb}KB is not fully covered by sequence {pattern_kb}"
+        )
+    return sector_sizes
+
+
+def _build_banked_sector_entries(
+    flash_kb: int,
+    bank_kb: int,
+    pattern_kb: Tuple[int, ...],
+    bank_address_stride_kb: int,
+) -> List[Tuple[int, int]]:
+    if sum(pattern_kb) != bank_kb:
+        raise ValueError(
+            f"Bank pattern {pattern_kb} does not sum to bank size {bank_kb}KB"
+        )
+
+    remaining_kb = flash_kb
+    bank_index = 0
+    sector_entries = []
+
+    while remaining_kb > 0:
+        bank_remaining_kb = min(remaining_kb, bank_kb)
+        bank_used_kb = 0
+        address = _FLASH_BASE + bank_index * bank_address_stride_kb * 1024
+
+        for size_kb in pattern_kb:
+            if bank_used_kb + size_kb > bank_remaining_kb:
+                break
+            size_bytes = size_kb * 1024
+            sector_entries.append((address, size_bytes))
+            address += size_bytes
+            bank_used_kb += size_kb
+
+        if bank_used_kb != bank_remaining_kb:
+            raise ValueError(
+                f"Bank pattern {pattern_kb} does not cover {bank_remaining_kb}KB"
+            )
+
+        remaining_kb -= bank_remaining_kb
+        bank_index += 1
+
+    return sector_entries
+
+
+def _build_sector_entries_from_rule(
+    rule: FlashRule,
+    flash_kb: int,
+) -> List[Tuple[int, int]]:
+    if rule.layout_type == "uniform":
+        if rule.size_bytes is None:
+            raise ValueError(f"Rule {rule.name} is missing size_bytes")
+        return _build_contiguous_sector_entries(
+            _build_uniform_sector_sizes(flash_kb, rule.size_bytes)
+        )
+
+    if rule.layout_type == "sequence":
+        return _build_contiguous_sector_entries(
+            _build_sequence_sector_sizes(flash_kb, rule.pattern_kb)
+        )
+
+    if rule.layout_type == "banked":
+        if rule.bank_kb is None:
+            raise ValueError(f"Rule {rule.name} is missing bank_kb")
+        bank_address_stride_kb = rule.bank_address_stride_kb or rule.bank_kb
+        return _build_banked_sector_entries(
+            flash_kb,
+            rule.bank_kb,
+            rule.pattern_kb,
+            bank_address_stride_kb,
+        )
+
+    raise ValueError(f"Unsupported flash layout type: {rule.layout_type}")
+
+
+@lru_cache(maxsize=1)
+def _load_flash_rules() -> Tuple[FlashRule, ...]:
+    rule_path = Path(__file__).resolve().with_name("STM32FlashLayoutRules.xml")
+    root = ET.parse(rule_path).getroot()
+    rules = []
+
+    for rule_elem in root.findall("rule"):
+        child_elements = list(rule_elem)
+        if len(child_elements) != 1:
+            raise ValueError("Each flash rule must contain exactly one layout element")
+
+        layout_elem = child_elements[0]
+        layout_tag = _local_name(layout_elem.tag)
+        size_bytes = None
+        pattern_kb: Tuple[int, ...] = tuple()
+        bank_kb = None
+
+        if layout_tag == "uniform":
+            size_bytes = _parse_rule_size_bytes(layout_elem)
+        elif layout_tag == "sequence":
+            pattern_kb = _parse_pattern_kb(layout_elem.attrib["sizes_kb"])
+        elif layout_tag == "banked":
+            bank_kb = int(layout_elem.attrib["bank_kb"], 0)
+            pattern_kb = _parse_pattern_kb(layout_elem.attrib["sizes_kb"])
+        else:
+            raise ValueError(f"Unsupported layout tag: {layout_tag}")
+
+        regex = rule_elem.attrib.get("regex")
+        rules.append(
+            FlashRule(
+                name=rule_elem.attrib["name"],
+                prefix=_normalize_optional(rule_elem.attrib.get("prefix")),
+                contains=_normalize_optional(rule_elem.attrib.get("contains")),
+                regex=re.compile(regex) if regex else None,
+                flash_kb=_parse_optional_int(rule_elem.attrib.get("flash_kb")),
+                flash_kb_min=_parse_optional_int(rule_elem.attrib.get("flash_kb_min")),
+                flash_kb_max=_parse_optional_int(rule_elem.attrib.get("flash_kb_max")),
+                layout_type=layout_tag,
+                size_bytes=size_bytes,
+                pattern_kb=pattern_kb,
+                bank_kb=bank_kb,
+                bank_address_stride_kb=_parse_optional_int(
+                    layout_elem.attrib.get("address_stride_kb")
+                ),
+            )
+        )
+
+    return tuple(rules)
+
+
+def _match_flash_rule(model: str, flash_kb: int) -> Optional[FlashRule]:
+    for rule in _load_flash_rules():
+        if rule.prefix is not None and not model.startswith(rule.prefix):
+            continue
+        if rule.contains is not None and rule.contains not in model:
+            continue
+        if rule.regex is not None and not rule.regex.search(model):
+            continue
+        if rule.flash_kb is not None and flash_kb != rule.flash_kb:
+            continue
+        if rule.flash_kb_min is not None and flash_kb < rule.flash_kb_min:
+            continue
+        if rule.flash_kb_max is not None and flash_kb > rule.flash_kb_max:
+            continue
+        return rule
+    return None
+
+
+def _parse_rule_size_bytes(elem: ET.Element) -> int:
+    if "size_bytes" in elem.attrib:
+        return int(elem.attrib["size_bytes"], 0)
+    if "size_kb" in elem.attrib:
+        return int(elem.attrib["size_kb"], 0) * 1024
+    raise ValueError("uniform layout must provide size_bytes or size_kb")
+
+
+def _parse_pattern_kb(spec: str) -> Tuple[int, ...]:
+    pattern = []
+    for token in spec.replace(" ", "").split(","):
+        if not token:
+            continue
+
+        if "x" in token.lower():
+            value_text, count_text = re.split(r"[xX]", token, maxsplit=1)
+            value_kb = int(value_text, 0)
+            count = int(count_text, 0)
+            pattern.extend([value_kb] * count)
+        else:
+            pattern.append(int(token, 0))
+
+    if not pattern:
+        raise ValueError(f"Invalid pattern specification: {spec}")
+    return tuple(pattern)
+
+
+def _normalize_optional(value: Optional[str]) -> Optional[str]:
+    return value.upper() if value else None
+
+
+def _parse_optional_int(value: Optional[str]) -> Optional[int]:
+    return int(value, 0) if value is not None else None
+
+
+def _local_name(tag: str) -> str:
+    return tag.split("}", 1)[-1]
 
 
 def main():
@@ -144,23 +393,16 @@ def main():
 
     LibXRPackageInfo.check_and_print()
 
-    """Command line interface for STM32 flash information tool"""
-
     def validate_model(model: str) -> bool:
-        """Validate STM32 model number format"""
-        return (
-                '-' not in model and
-                model.upper().startswith("STM32") and
-                len(model) > 8
-        )
+        return "-" not in model and model.upper().startswith("STM32") and len(model) > 8
 
     if len(sys.argv) != 2:
         print("STM32 Flash Information Tool")
         print("Usage:")
-        print(f"  xr_stm32_flash <STM32_MODEL>")
+        print("  xr_stm32_flash <STM32_MODEL>")
         print("\nExamples:")
-        print(f"  xr_stm32_flash STM32F103C8T6")
-        print(f"  xr_stm32_flash STM32L476RG")
+        print("  xr_stm32_flash STM32F103C8T6")
+        print("  xr_stm32_flash STM32L476RG")
         sys.exit(1)
 
     model = sys.argv[1].strip().upper()
@@ -170,20 +412,22 @@ def main():
             raise ValueError(f"Invalid STM32 model format: {model}")
 
         info = layout_flash(model)
-        print(yaml.safe_dump(
-            flash_info_to_dict(info),
-            sort_keys=False,
-            allow_unicode=True,
-            default_flow_style=False
-        ))
+        print(
+            yaml.safe_dump(
+                flash_info_to_dict(info),
+                sort_keys=False,
+                allow_unicode=True,
+                default_flow_style=False,
+            )
+        )
 
-    except Exception as e:
+    except Exception as error:
         print(f"\nERROR: Failed to process model {model}")
-        print(f"Reason: {str(e)}")
+        print(f"Reason: {str(error)}")
         print("\nStack trace:")
         traceback.print_exc()
         sys.exit(2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/libxr/STM32FlashLayoutRules.xml
+++ b/src/libxr/STM32FlashLayoutRules.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<flash-layout-rules version="1">
+  <rule name="stm32_f105_f107" regex="^STM32F10[57]">
+    <uniform size_kb="2" />
+  </rule>
+  <rule name="stm32_f1_small" prefix="STM32F1" flash_kb_max="128">
+    <uniform size_kb="1" />
+  </rule>
+  <rule name="stm32_f1_large" prefix="STM32F1" flash_kb_min="256">
+    <uniform size_kb="2" />
+  </rule>
+  <rule name="stm32_f2" prefix="STM32F2">
+    <banked bank_kb="1024" sizes_kb="16x4,64,128x7" />
+  </rule>
+  <rule name="stm32_f4" prefix="STM32F4">
+    <banked bank_kb="1024" sizes_kb="16x4,64,128x7" />
+  </rule>
+  <rule name="stm32_u5" prefix="STM32U5">
+    <uniform size_kb="8" />
+  </rule>
+  <rule name="stm32_u3" prefix="STM32U3">
+    <uniform size_kb="8" />
+  </rule>
+  <rule name="stm32_wl_l4_g0_g4_c0_u0" regex="^STM32(WL|L4|G0|G4|C0|U0)">
+    <uniform size_kb="2" />
+  </rule>
+  <rule name="stm32_l0" prefix="STM32L0">
+    <uniform size_bytes="128" />
+  </rule>
+  <rule name="stm32_wba" prefix="STM32WBA">
+    <uniform size_kb="8" />
+  </rule>
+  <rule name="stm32_wb" prefix="STM32WB">
+    <uniform size_kb="4" />
+  </rule>
+  <rule name="stm32_h7a3_b0_b3" regex="^STM32H7(A3|B0|B3)">
+    <uniform size_kb="8" />
+  </rule>
+  <rule name="stm32_h5" prefix="STM32H5">
+    <uniform size_kb="8" />
+  </rule>
+  <rule name="stm32_h7_die450_1m_dual_bank_gap" regex="^STM32H7(42|43|45|47)" flash_kb="1024">
+    <banked bank_kb="512" address_stride_kb="1024" sizes_kb="128x4" />
+  </rule>
+  <rule name="stm32_h7r_h7s" regex="^STM32H7(R3|R7|S3|S7)">
+    <uniform size_kb="8" />
+  </rule>
+  <rule name="stm32_h7" prefix="STM32H7">
+    <uniform size_kb="128" />
+  </rule>
+  <rule name="stm32_f7" prefix="STM32F7">
+    <sequence sizes_kb="32x4,128,256x7" />
+  </rule>
+  <rule name="stm32_f0_small_page" regex="^STM32F0[345]">
+    <uniform size_kb="1" />
+  </rule>
+  <rule name="stm32_f3" prefix="STM32F3">
+    <uniform size_kb="2" />
+  </rule>
+  <rule name="stm32_f0" prefix="STM32F0">
+    <uniform size_kb="2" />
+  </rule>
+  <rule name="stm32_l1" prefix="STM32L1">
+    <uniform size_bytes="256" />
+  </rule>
+  <rule name="stm32_default" prefix="STM32">
+    <uniform size_kb="1" />
+  </rule>
+</flash-layout-rules>


### PR DESCRIPTION
This change fixes two separate but related reliability gaps in the Python code generator package.

The first part fixes STM32 flash layout generation. The previous implementation still relied on a hardcoded condition chain in `STM32FlashGenerator.py`, which produced incorrect layouts for several STM32 families. In practice this caused wrong `flash_map.hpp` output for parts such as STM32F7, newer STM32H5/U3/U5 variants, STM32H7 1 MB dual-bank parts with a bank address gap, and STM32H7R/H7S parts with 8 KB erase sectors. It also had no explicit handling for STM32N6 devices, which do not provide internal user flash. The generator is now driven by a packaged XML rule file, `STM32FlashLayoutRules.xml`, and the runtime resolves layouts from that single source. This lets the package describe uniform, sequence, and banked layouts cleanly, including the `0x08100000` second-bank stride required by 1 MB DIE450 H7 parts. STM32N6 now fails explicitly instead of silently producing an invalid flash map. The package metadata is also updated so the XML rule file is shipped with the wheel and sdist, and the patch version is bumped from `5.1.8` to `5.1.9`.

The second part adds a CI guard against Python-version compatibility regressions. The existing workflow already built the package across a Python version matrix and ran `xr_cubemx_cfg`, but that still leaves a gap where a top-level module can become unimportable on one interpreter version without being exercised by the existing smoke path. The new `scripts/ci_import_smoke.py` script imports every top-level `libxr` module from the installed package, and the workflow now runs it immediately after package installation in the matrix job. This is meant to catch the same class of import-time compatibility regression that recently showed up in the XRobot tooling line.

Validation for this change was done in two ways. For the flash layout path, representative STM32 models were checked directly against the updated generator output, including `STM32F746ZGT6`, `STM32H723VEHX`, `STM32H743IGKX`, `STM32H743IIKX`, and `STM32H7R3V8HX`. For the packaging and CI guard, the package was built and installed into a clean virtual environment and `python scripts/ci_import_smoke.py` completed successfully, importing all top-level modules. On the Windows working copy used by `xr_cubemx_cfg`, the same import smoke and STM32 flash checks were also run before preparing this PR.

## Summary by Sourcery

Update STM32 flash layout generation to use XML-driven rules and improve CI coverage for Python import compatibility.

New Features:
- Add XML-based STM32 flash layout rules file to drive flash map generation across STM32 families.
- Introduce a CI import smoke script that imports all top-level libxr modules in the installed package.

Bug Fixes:
- Correct STM32 flash layouts for multiple STM32 series, including dual-bank and small-sector variants, and explicitly reject STM32N6 without internal flash.

Enhancements:
- Refactor STM32 flash layout generator into a rule-based engine with reusable helpers and improved error reporting.
- Normalize and modernize generated LibXR CMake configuration to enforce C++20 settings consistently.

Build:
- Package STM32FlashLayoutRules.xml in the libxr distribution and bump the project version to 5.1.9.

CI:
- Extend the Python package CI workflow to run the new import smoke check after installing the built wheel.