### PR TITLE
fix(stm32): merge stale pin GPIO aliases

### DIFF
--- a/scripts/gpio_alias_smoke.py
+++ b/scripts/gpio_alias_smoke.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Smoke test for stale GPIO device aliases produced from CubeMX pin names."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        config_path = tmp_dir / "config.yaml"
+        output_path = tmp_dir / "app_main.cpp"
+        libxr_config_path = tmp_dir / "libxr_config.yaml"
+
+        config = {
+            "Mcu": {"Family": "STM32H7", "Type": "STM32H723VGTx"},
+            "Timebase": {"Source": "SysTick"},
+            "GPIO": {"PC14": {"Signal": "GPIO_Output"}},
+            "Peripherals": {},
+            "device_aliases": {
+                "PC14_OSC32_IN": {
+                    "type": "GPIO",
+                    "aliases": ["PC14_OSC32_IN"],
+                }
+            },
+        }
+        config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+        libxr_config_path.write_text("SYSTEM: None\n", encoding="utf-8")
+
+        command = [
+            sys.executable,
+            "-m",
+            "libxr.GeneratorCodeSTM32",
+            "-i",
+            str(config_path),
+            "-o",
+            str(output_path),
+            "--xrobot",
+            "--hw-cntr",
+        ]
+        result = subprocess.run(
+            command,
+            cwd=repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        if result.returncode != 0:
+            print(result.stdout)
+            return result.returncode
+
+        generated = output_path.read_text(encoding="utf-8")
+        required = 'LibXR::Entry<LibXR::GPIO>({PC14, {"PC14", "PC14_OSC32_IN"}})'
+        forbidden = "LibXR::Entry<LibXR::GPIO>({PC14_OSC32_IN"
+
+        if required not in generated:
+            print("missing merged PC14 alias entry")
+            print(generated)
+            return 1
+        if forbidden in generated:
+            print("stale PC14_OSC32_IN variable entry was generated")
+            print(generated)
+            return 1
+
+    print("GPIO alias smoke passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gpio_alias_smoke.py
+++ b/scripts/gpio_alias_smoke.py
@@ -3,12 +3,46 @@
 
 from __future__ import annotations
 
-import subprocess
+import re
 import sys
 import tempfile
 from pathlib import Path
 
 import yaml
+
+
+GPIO_PC14_ENTRY_RE = re.compile(
+    r"LibXR::Entry<LibXR::GPIO>\(\{\s*PC14\s*,\s*\{(?P<aliases>[^}]*)\}\s*\}\)"
+)
+STALE_PC14_ENTRY_RE = re.compile(
+    r"LibXR::Entry<LibXR::GPIO>\(\{\s*PC14_OSC32_IN\b"
+)
+
+
+def run_stm32_generator(repo_root: Path, config_path: Path, output_path: Path) -> int:
+    sys.path.insert(0, str(repo_root / "src"))
+
+    from libxr import GeneratorCodeSTM32  # pylint: disable=import-outside-toplevel
+
+    old_argv = sys.argv[:]
+    sys.argv = [
+        "libxr.GeneratorCodeSTM32",
+        "-i",
+        str(config_path),
+        "-o",
+        str(output_path),
+        "--xrobot",
+        "--hw-cntr",
+    ]
+    try:
+        try:
+            GeneratorCodeSTM32.main()
+        except SystemExit as exit_status:
+            return exit_status.code if isinstance(exit_status.code, int) else 1
+    finally:
+        sys.argv = old_argv
+
+    return 0
 
 
 def main() -> int:
@@ -34,38 +68,26 @@ def main() -> int:
         config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
         libxr_config_path.write_text("SYSTEM: None\n", encoding="utf-8")
 
-        command = [
-            sys.executable,
-            "-m",
-            "libxr.GeneratorCodeSTM32",
-            "-i",
-            str(config_path),
-            "-o",
-            str(output_path),
-            "--xrobot",
-            "--hw-cntr",
-        ]
-        result = subprocess.run(
-            command,
-            cwd=repo_root,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=False,
-        )
-        if result.returncode != 0:
-            print(result.stdout)
-            return result.returncode
+        result = run_stm32_generator(repo_root, config_path, output_path)
+        if result != 0:
+            return result
 
         generated = output_path.read_text(encoding="utf-8")
-        required = 'LibXR::Entry<LibXR::GPIO>({PC14, {"PC14", "PC14_OSC32_IN"}})'
-        forbidden = "LibXR::Entry<LibXR::GPIO>({PC14_OSC32_IN"
+        entry = GPIO_PC14_ENTRY_RE.search(generated)
 
-        if required not in generated:
+        if entry is None:
             print("missing merged PC14 alias entry")
             print(generated)
             return 1
-        if forbidden in generated:
+
+        aliases = set(re.findall(r'"([^"]+)"', entry.group("aliases")))
+        expected_aliases = {"PC14", "PC14_OSC32_IN"}
+        if not expected_aliases.issubset(aliases):
+            print(f"PC14 alias entry missing aliases: {sorted(expected_aliases - aliases)}")
+            print(generated)
+            return 1
+
+        if STALE_PC14_ENTRY_RE.search(generated):
             print("stale PC14_OSC32_IN variable entry was generated")
             print(generated)
             return 1

--- a/scripts/gpio_alias_smoke.py
+++ b/scripts/gpio_alias_smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import re
 import sys
 import tempfile
+from importlib import import_module, reload
 from pathlib import Path
 
 import yaml
@@ -19,10 +20,23 @@ STALE_PC14_ENTRY_RE = re.compile(
 )
 
 
-def run_stm32_generator(repo_root: Path, config_path: Path, output_path: Path) -> int:
-    sys.path.insert(0, str(repo_root / "src"))
+LEGACY_ALIAS_CASES = {
+    "typed-dict": {
+        "type": "GPIO",
+        "aliases": ["PC14_OSC32_IN"],
+    },
+    "legacy-list": ["PC14_OSC32_IN"],
+    "legacy-string": "PC14_OSC32_IN",
+}
 
-    from libxr import GeneratorCodeSTM32  # pylint: disable=import-outside-toplevel
+
+def run_stm32_generator(repo_root: Path, config_path: Path, output_path: Path) -> int:
+    src_path = str(repo_root / "src")
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+
+    generator = import_module("libxr.GeneratorCodeSTM32")
+    generator = reload(generator)
 
     old_argv = sys.argv[:]
     sys.argv = [
@@ -36,7 +50,7 @@ def run_stm32_generator(repo_root: Path, config_path: Path, output_path: Path) -
     ]
     try:
         try:
-            GeneratorCodeSTM32.main()
+            generator.main()
         except SystemExit as exit_status:
             return exit_status.code if isinstance(exit_status.code, int) else 1
     finally:
@@ -47,6 +61,16 @@ def run_stm32_generator(repo_root: Path, config_path: Path, output_path: Path) -
 
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[1]
+    for case_name, alias_entry in LEGACY_ALIAS_CASES.items():
+        result = run_alias_case(repo_root, case_name, alias_entry)
+        if result != 0:
+            return result
+
+    print("GPIO alias smoke passed.")
+    return 0
+
+
+def run_alias_case(repo_root: Path, case_name: str, alias_entry) -> int:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)
         config_path = tmp_dir / "config.yaml"
@@ -58,15 +82,18 @@ def main() -> int:
             "Timebase": {"Source": "SysTick"},
             "GPIO": {"PC14": {"Signal": "GPIO_Output"}},
             "Peripherals": {},
-            "device_aliases": {
-                "PC14_OSC32_IN": {
-                    "type": "GPIO",
-                    "aliases": ["PC14_OSC32_IN"],
-                }
-            },
         }
         config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
-        libxr_config_path.write_text("SYSTEM: None\n", encoding="utf-8")
+        libxr_config = {
+            "SYSTEM": "None",
+            "device_aliases": {
+                "PC14_OSC32_IN": alias_entry,
+            },
+        }
+        libxr_config_path.write_text(
+            yaml.safe_dump(libxr_config, sort_keys=False),
+            encoding="utf-8",
+        )
 
         result = run_stm32_generator(repo_root, config_path, output_path)
         if result != 0:
@@ -76,23 +103,25 @@ def main() -> int:
         entry = GPIO_PC14_ENTRY_RE.search(generated)
 
         if entry is None:
-            print("missing merged PC14 alias entry")
+            print(f"{case_name}: missing merged PC14 alias entry")
             print(generated)
             return 1
 
         aliases = set(re.findall(r'"([^"]+)"', entry.group("aliases")))
         expected_aliases = {"PC14", "PC14_OSC32_IN"}
         if not expected_aliases.issubset(aliases):
-            print(f"PC14 alias entry missing aliases: {sorted(expected_aliases - aliases)}")
+            print(
+                f"{case_name}: PC14 alias entry missing aliases: "
+                f"{sorted(expected_aliases - aliases)}"
+            )
             print(generated)
             return 1
 
         if STALE_PC14_ENTRY_RE.search(generated):
-            print("stale PC14_OSC32_IN variable entry was generated")
+            print(f"{case_name}: stale PC14_OSC32_IN variable entry was generated")
             print(generated)
             return 1
 
-    print("GPIO alias smoke passed.")
     return 0
 
 

--- a/src/libxr/GeneratorCodeSTM32.py
+++ b/src/libxr/GeneratorCodeSTM32.py
@@ -41,6 +41,48 @@ libxr_settings = {
 # --------------------------
 # Configuration Initialization
 # --------------------------
+def _normalize_alias_list(aliases) -> list:
+    if aliases is None:
+        return []
+    if isinstance(aliases, (list, tuple, set)):
+        return [str(alias) for alias in aliases if alias is not None]
+    return [str(aliases)]
+
+
+def _normalize_device_alias_entry(dev: str, entry) -> dict:
+    if isinstance(entry, dict):
+        dev_type = entry.get("type", "Unknown") or "Unknown"
+        aliases = _normalize_alias_list(entry.get("aliases", []))
+    elif isinstance(entry, (list, tuple, set, str)):
+        dev_type = "Unknown"
+        aliases = _normalize_alias_list(entry)
+    else:
+        logging.warning(f"Ignoring invalid device alias entry for '{dev}'")
+        return None
+
+    return {
+        "type": str(dev_type),
+        "aliases": aliases,
+    }
+
+
+def _normalize_device_aliases(raw_aliases) -> dict:
+    if raw_aliases is None:
+        return {}
+    if not isinstance(raw_aliases, dict):
+        logging.warning("Ignoring invalid device_aliases config, expected a mapping")
+        return {}
+
+    normalized = {}
+    for dev, entry in raw_aliases.items():
+        dev_name = str(dev)
+        meta = _normalize_device_alias_entry(dev_name, entry)
+        if meta is not None:
+            normalized[dev_name] = meta
+
+    return normalized
+
+
 def initialize_device_aliases(use_xrobot: bool) -> None:
     global device_aliases
     device_aliases.clear()
@@ -48,7 +90,7 @@ def initialize_device_aliases(use_xrobot: bool) -> None:
     if not use_xrobot:
         return
 
-    saved_aliases = libxr_settings.get("device_aliases", {})
+    saved_aliases = _normalize_device_aliases(libxr_settings.get("device_aliases", {}))
 
     # 插入默认设备
     if "power_manager" not in saved_aliases:
@@ -93,7 +135,10 @@ def _register_device(name: str, dev_type: str):
         }
         return
 
-    meta = device_aliases[name]
+    meta = _normalize_device_alias_entry(name, device_aliases[name])
+    if meta is None:
+        meta = {"type": dev_type, "aliases": [name]}
+    device_aliases[name] = meta
     meta["type"] = dev_type
     aliases = meta.setdefault("aliases", [])
     if name not in aliases:
@@ -136,27 +181,9 @@ def load_configuration(file_path: str, use_hw_cntr: bool) -> dict:
 
             if use_hw_cntr:
                 if 'device_aliases' in config:
-                    new_aliases = {}
-                    for dev, entry in config['device_aliases'].items():
-                        if isinstance(entry, list):
-                            new_aliases[dev] = {
-                                "type": "Unknown",
-                                "aliases": entry
-                            }
-                        elif isinstance(entry, str):
-                            new_aliases[dev] = {
-                                "type": "Unknown",
-                                "aliases": [entry]
-                            }
-                        elif isinstance(entry, dict):
-                            # 兼容新版格式（已带 type 和 aliases）
-                            new_aliases[dev] = {
-                                "type": entry.get("type", "Unknown"),
-                                "aliases": entry.get("aliases", [])
-                                if isinstance(entry.get("aliases"), list)
-                                else [entry.get("aliases")]
-                            }
-                    libxr_settings['device_aliases'] = new_aliases
+                    libxr_settings['device_aliases'] = _normalize_device_aliases(
+                        config['device_aliases']
+                    )
 
             # Basic schema validation
             required_sections = ["Mcu", "GPIO", "Peripherals"]
@@ -302,19 +329,22 @@ def _merge_pin_derived_gpio_aliases() -> None:
     physical pin name, for example ``PC14``. In that case the old name should
     remain a hardware alias, not a separate C++ variable reference.
     """
+    global device_aliases
+    device_aliases = _normalize_device_aliases(device_aliases)
+
     for dev, meta in list(device_aliases.items()):
-        if meta.get("type") != "GPIO":
+        if meta.get("type") not in ("GPIO", "Unknown"):
             continue
 
         candidates = [dev]
-        candidates.extend(meta.get("aliases", []))
+        candidates.extend(_normalize_alias_list(meta.get("aliases", [])))
         target = None
         for candidate in candidates:
             match = PIN_DERIVED_GPIO_ALIAS_RE.match(str(candidate))
             if match:
                 pin_name = match.group(1)
                 pin_meta = device_aliases.get(pin_name)
-                if pin_meta and pin_meta.get("type") == "GPIO":
+                if isinstance(pin_meta, dict) and pin_meta.get("type") == "GPIO":
                     target = pin_name
                     break
 
@@ -322,10 +352,10 @@ def _merge_pin_derived_gpio_aliases() -> None:
             continue
 
         target_meta = device_aliases[target]
-        aliases = set(target_meta.get("aliases", []))
+        aliases = set(_normalize_alias_list(target_meta.get("aliases", [])))
         aliases.add(target)
         aliases.add(dev)
-        aliases.update(meta.get("aliases", []))
+        aliases.update(_normalize_alias_list(meta.get("aliases", [])))
         target_meta["aliases"] = sorted(aliases)
         del device_aliases[dev]
 

--- a/src/libxr/GeneratorCodeSTM32.py
+++ b/src/libxr/GeneratorCodeSTM32.py
@@ -11,6 +11,8 @@ import yaml
 
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
+PIN_DERIVED_GPIO_ALIAS_RE = re.compile(r"^(P[A-K]\d+)(?:_|$)")
+
 # --------------------------
 # Global Configuration
 # --------------------------
@@ -308,7 +310,7 @@ def _merge_pin_derived_gpio_aliases() -> None:
         candidates.extend(meta.get("aliases", []))
         target = None
         for candidate in candidates:
-            match = re.match(r"^(P[A-K]\d+)(?:_|$)", str(candidate))
+            match = PIN_DERIVED_GPIO_ALIAS_RE.match(str(candidate))
             if match:
                 pin_name = match.group(1)
                 pin_meta = device_aliases.get(pin_name)

--- a/src/libxr/GeneratorCodeSTM32.py
+++ b/src/libxr/GeneratorCodeSTM32.py
@@ -89,6 +89,13 @@ def _register_device(name: str, dev_type: str):
             "type": dev_type,
             "aliases": [name]
         }
+        return
+
+    meta = device_aliases[name]
+    meta["type"] = dev_type
+    aliases = meta.setdefault("aliases", [])
+    if name not in aliases:
+        aliases.append(name)
 
 
 # --------------------------
@@ -282,6 +289,43 @@ def generate_gpio_alias(port: str, gpio_data: dict, project_data: dict) -> str:
     _register_device(var_name, "GPIO")
 
     return f"{var_name}({port_define}, {pin_define}{irq_str})"
+
+
+def _merge_pin_derived_gpio_aliases() -> None:
+    """Attach stale pin-derived GPIO aliases to the currently generated pin object.
+
+    Older ``libxr_config.yaml`` files may retain aliases such as
+    ``PC14_OSC32_IN`` from CubeMX pin tokens. When the current IOC has no
+    ``GPIO_Label`` for that pin, the generator creates the C++ object as the
+    physical pin name, for example ``PC14``. In that case the old name should
+    remain a hardware alias, not a separate C++ variable reference.
+    """
+    for dev, meta in list(device_aliases.items()):
+        if meta.get("type") != "GPIO":
+            continue
+
+        candidates = [dev]
+        candidates.extend(meta.get("aliases", []))
+        target = None
+        for candidate in candidates:
+            match = re.match(r"^(P[A-K]\d+)(?:_|$)", str(candidate))
+            if match:
+                pin_name = match.group(1)
+                pin_meta = device_aliases.get(pin_name)
+                if pin_meta and pin_meta.get("type") == "GPIO":
+                    target = pin_name
+                    break
+
+        if target is None or target == dev:
+            continue
+
+        target_meta = device_aliases[target]
+        aliases = set(target_meta.get("aliases", []))
+        aliases.add(target)
+        aliases.add(dev)
+        aliases.update(meta.get("aliases", []))
+        target_meta["aliases"] = sorted(aliases)
+        del device_aliases[dev]
 
 
 def _get_exti_irq(pin_num: int, port: str, is_exti: bool, mcu_family: str) -> str:
@@ -1051,6 +1095,8 @@ def generate_xrobot_hardware_container() -> str:
     Each device is associated with its logical aliases.
     """
     global device_aliases
+
+    _merge_pin_derived_gpio_aliases()
 
     # Normalize device_aliases structure
     libxr_settings["device_aliases"] = {


### PR DESCRIPTION
## Summary
- keep generated GPIO object names as the current IOC-derived physical pin or label
- merge stale pin-derived GPIO aliases such as PC14_OSC32_IN onto the current generated pin object instead of emitting a non-existent C++ variable reference
- add a smoke test for the stale alias case

## Validation
- PYTHONPATH=src python3 scripts/ci_import_smoke.py
- PYTHONPATH=src python3 scripts/gpio_alias_smoke.py
- verified QDU-Robomaster/bsp-dev-mc02 generation maps PC14_OSC32_IN onto PC14 without referencing a missing variable

## Summary by Sourcery

在生成硬件容器之前，处理过时的 STM32 GPIO 引脚名称别名，将它们合并到当前物理引脚条目中。

Bug Fixes:
- 通过将仅作为过时 CubeMX 派生别名存在的引脚别名附加到当前引脚对象上，避免为这些引脚生成 C++ GPIO 变量。

Enhancements:
- 规范设备别名注册逻辑，使其在更新现有条目的同时保留别名列表。
- 整合 GPIO 别名元数据，使引脚派生的别名与其物理引脚在生成的配置中共享同一个硬件条目。

Tests:
- 添加一个冒烟测试，验证像 `PC14_OSC32_IN` 这样的过时 GPIO 别名会被合并到 `PC14` 条目中，并且不会在生成的代码中产生单独的变量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle stale STM32 GPIO pin-name aliases by merging them into the current physical pin entry before generating hardware containers.

Bug Fixes:
- Prevent generation of C++ GPIO variables for pins that only exist as outdated CubeMX-derived aliases by attaching those aliases to the current pin object.

Enhancements:
- Normalize device alias registration to update existing entries while preserving alias lists.
- Consolidate GPIO alias metadata so that pin-derived aliases and their physical pin share a single hardware entry in the generated configuration.

Tests:
- Add a smoke test that verifies stale GPIO aliases like PC14_OSC32_IN are merged onto the PC14 entry and do not produce a separate variable in the generated code.

</details>