### PR TITLE
fix(stm32): CDCUart 显式端点号，同步 libxr USB 重构

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libxr"
-version = "5.2.2"
+version = "5.2.3"
 description = "C++ code generator for LibXR-based embedded systems, supporting STM32 and modular robotics applications."
 requires-python = ">=3.8"
 authors = [

--- a/src/libxr/GeneratorCodeSTM32.py
+++ b/src/libxr/GeneratorCodeSTM32.py
@@ -837,8 +837,14 @@ class PeripheralFactory:
             "LibXR::USB::DescriptorStrings::Language::EN_US, "
             f"\"{manufacturer}\", \"{product}\", \"{serial}\");"
         )
-        # CDC construction with queue size
-        code.append(f"  LibXR::USB::CDCUart {cdc_var}({cdc_rx_fifo_size}, {cdc_tx_fifo_size}, {cdc_queue_size});\n")
+        # CDC construction with explicit endpoint numbers.
+        # Fixed EP layout: EP1 = CDC data bulk IN/OUT, EP2 = CDC notification IN.
+        code.append(
+            f"  LibXR::USB::CDCUart {cdc_var}("
+            "LibXR::USB::Endpoint::EPNumber::EP1, "
+            "LibXR::USB::Endpoint::EPNumber::EP1, "
+            "LibXR::USB::Endpoint::EPNumber::EP2, "
+            f"{cdc_rx_fifo_size}, {cdc_tx_fifo_size}, {cdc_queue_size});\n")
 
         if is_otg:
             code.append(f"  {instance_type} {obj}(")


### PR DESCRIPTION
libxr USB 端点池重构（已合入 libxr master）把所有 USB device class 的构造函数改为 **EP 号必填、提到参数最前**。这是破坏性 API 变更，生成器生成的 `CDCUart` 实例化代码需同步。

## 改动
`GeneratorCodeSTM32.py`：CDCUart 实例化从旧签名
`CDCUart(rx, tx, queue)`
改为新签名
`CDCUart(EP1, EP1, EP2, rx, tx, queue)`
按生成器固定的 EP 布局显式传入端点号（EP1 = CDC data bulk IN/OUT，EP2 = CDC comm 中断 IN）。

## 验证
`stm32-target-test` CI 会 checkout libxr master（已含重构）并用 arm-none-eabi-gcc 真编译生成的固件——本 PR 前该编译应为失败状态（旧签名配新 libxr），本 PR 修复它。

## Summary by Sourcery

错误修复：
- 通过在生成代码中传递显式端点编号，修复了针对更新后的 libxr USB CDCUart API 时，STM32 生成固件构建失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix STM32-generated firmware build failures against the updated libxr USB CDCUart API by passing explicit endpoint numbers in the generated code.

</details>