### PR TITLE
fix(cubemx): update clean stale libxr checkout

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -188,6 +188,10 @@ jobs:
         run: |
           python ./scripts/cubemx_runner_smoke.py
 
+      - name: LibXR submodule policy smoke check
+        run: |
+          python ./scripts/libxr_submodule_smoke.py
+
       - name: Checkout BSP Compatibility Test Repo
         uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -131,14 +131,13 @@ Parses `.ioc`, generates YAML and C++ code, patches interrupt handlers, and init
   显式指定 LibXR 仓库 commit 版本；提供该参数时工具会切到这个 commit。
   Explicitly select the LibXR repository commit; when provided, the tool checks out this commit.
 
-  不提供 `--commit` 时，工具优先保留工程已有的 LibXR 子模块版本。新 clone 工程会按工程记录的
-  submodule gitlink 初始化；如果该 gitlink 已经落后于包内默认 commit，当前 checkout 仍停在该 gitlink，
-  且子模块没有本地修改，工具会升级到包内默认 commit。已有子模块如果被用户切到非默认版本，不会被包内默认 commit 覆盖。
-  When `--commit` is omitted, the existing project LibXR submodule version is preserved. A freshly cloned
-  project follows its recorded submodule gitlink; if that gitlink is older than the package default commit,
-  the current checkout still stays at that gitlink, and the submodule is clean, the tool upgrades it to the
-  package default. An existing submodule manually moved away from the package default will not be overwritten
-  by code generation.
+  不提供 `--commit` 时，如果 LibXR checkout 干净且比包内默认 commit 旧，工具会将其升级到默认 commit；
+  即使工程 gitlink 已记录默认 commit、实际 checkout 仍停在旧版本，也会自动修正。checkout 已是默认版本、
+  比默认版本新、与默认版本分叉或包含本地修改时均保持不变。如需精确切换版本，请显式使用 `--commit`。
+  When `--commit` is omitted, a clean LibXR checkout older than the package default commit is upgraded to that
+  default, even if the project gitlink already records the default while the checkout itself is stale. A
+  checkout that is already current, newer than the package default, has diverged from it, or contains local
+  changes is preserved. Use `--commit` to request an exact revision explicitly.
 
 - `--git-source`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libxr"
-version = "5.2.3"
+version = "5.2.4"
 description = "C++ code generator for LibXR-based embedded systems, supporting STM32 and modular robotics applications."
 requires-python = ">=3.8"
 authors = [

--- a/scripts/libxr_submodule_smoke.py
+++ b/scripts/libxr_submodule_smoke.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Smoke-test LibXR submodule update policy with local Git repositories."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import subprocess
+import sys
+import tempfile
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+sys.path.insert(0, str(SRC_DIR))
+
+from libxr.ConfigCubemxProject import add_libxr  # noqa: E402
+
+
+def git(*args: str, cwd: Optional[Path] = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def commit_file(repo: Path, name: str, text: str) -> str:
+    (repo / name).write_text(text, encoding="utf-8")
+    git("add", name, cwd=repo)
+    git("commit", "-m", text, cwd=repo)
+    return git("rev-parse", "HEAD", cwd=repo)
+
+
+def create_libxr_remote(root: Path) -> Tuple[Path, str, str, str, str]:
+    source = root / "libxr-source"
+    source.mkdir()
+    git("init", "-b", "master", cwd=source)
+    git("config", "user.name", "Smoke Test", cwd=source)
+    git("config", "user.email", "smoke@example.com", cwd=source)
+    old_commit = commit_file(source, "version.txt", "old")
+    default_commit = commit_file(source, "version.txt", "default")
+    newer_commit = commit_file(source, "version.txt", "newer")
+    git("checkout", "-b", "divergent", old_commit, cwd=source)
+    divergent_commit = commit_file(source, "divergent.txt", "divergent")
+    git("checkout", "master", cwd=source)
+
+    remote = root / "libxr.git"
+    git("clone", "--bare", str(source), str(remote), cwd=root)
+    return remote, old_commit, default_commit, newer_commit, divergent_commit
+
+
+def create_project(
+    root: Path,
+    name: str,
+    remote: Path,
+    recorded_commit: str,
+    checkout_commit: str,
+) -> Tuple[Path, Path]:
+    project = root / name
+    project.mkdir()
+    git("init", "-b", "master", cwd=project)
+    git("config", "user.name", "Smoke Test", cwd=project)
+    git("config", "user.email", "smoke@example.com", cwd=project)
+    git("-c", "protocol.file.allow=always", "submodule", "add", str(remote),
+        "Middlewares/Third_Party/LibXR", cwd=project)
+    checkout = project / "Middlewares" / "Third_Party" / "LibXR"
+    git("checkout", recorded_commit, cwd=checkout)
+    git("add", ".gitmodules", "Middlewares/Third_Party/LibXR", cwd=project)
+    git("commit", "-m", "add LibXR", cwd=project)
+    git("checkout", checkout_commit, cwd=checkout)
+    return project, checkout
+
+
+@contextlib.contextmanager
+def allow_file_protocol():
+    old_value = os.environ.get("GIT_ALLOW_PROTOCOL")
+    os.environ["GIT_ALLOW_PROTOCOL"] = "file"
+    try:
+        yield
+    finally:
+        if old_value is None:
+            os.environ.pop("GIT_ALLOW_PROTOCOL", None)
+        else:
+            os.environ["GIT_ALLOW_PROTOCOL"] = old_value
+
+
+def assert_head(checkout: Path, expected: str, scenario: str) -> None:
+    actual = git("rev-parse", "HEAD", cwd=checkout)
+    if actual != expected:
+        raise AssertionError(f"{scenario}: expected {expected}, got {actual}")
+
+
+def run_policy_checks(root: Path) -> None:
+    remote, old_commit, default_commit, newer_commit, divergent_commit = (
+        create_libxr_remote(root)
+    )
+
+    project, checkout = create_project(
+        root, "stale-checkout", remote,
+        recorded_commit=default_commit, checkout_commit=old_commit
+    )
+    add_libxr(project, default_libxr_commit=default_commit)
+    assert_head(checkout, default_commit, "stale checkout with current gitlink")
+
+    project, checkout = create_project(
+        root, "old-gitlink", remote,
+        recorded_commit=old_commit, checkout_commit=old_commit
+    )
+    add_libxr(project, default_libxr_commit=default_commit)
+    assert_head(checkout, default_commit, "old checkout with old gitlink")
+
+    project, checkout = create_project(
+        root, "current", remote,
+        recorded_commit=default_commit, checkout_commit=default_commit
+    )
+    add_libxr(project, default_libxr_commit=default_commit)
+    assert_head(checkout, default_commit, "current checkout")
+
+    project, checkout = create_project(
+        root, "newer", remote,
+        recorded_commit=default_commit, checkout_commit=newer_commit
+    )
+    add_libxr(project, default_libxr_commit=default_commit)
+    assert_head(checkout, newer_commit, "newer checkout")
+
+    project, checkout = create_project(
+        root, "divergent", remote,
+        recorded_commit=default_commit, checkout_commit=divergent_commit
+    )
+    add_libxr(project, default_libxr_commit=default_commit)
+    assert_head(checkout, divergent_commit, "divergent checkout")
+
+    project, checkout = create_project(
+        root, "dirty", remote,
+        recorded_commit=old_commit, checkout_commit=old_commit
+    )
+    (checkout / "version.txt").write_text("local changes", encoding="utf-8")
+    add_libxr(project, default_libxr_commit=default_commit)
+    assert_head(checkout, old_commit, "dirty old checkout")
+    if git("status", "--porcelain", cwd=checkout) == "":
+        raise AssertionError("dirty old checkout: local changes were lost")
+
+    project, checkout = create_project(
+        root, "explicit", remote,
+        recorded_commit=old_commit, checkout_commit=newer_commit
+    )
+    add_libxr(
+        project, libxr_commit=old_commit, default_libxr_commit=default_commit
+    )
+    assert_head(checkout, old_commit, "explicit commit")
+
+
+def main() -> int:
+    with allow_file_protocol(), tempfile.TemporaryDirectory(
+        prefix="libxr_submodule_smoke_"
+    ) as tmp:
+        with contextlib.redirect_stdout(io.StringIO()):
+            run_policy_checks(Path(tmp))
+    print("LibXR submodule policy smoke checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/libxr/ConfigCubemxProject.py
+++ b/src/libxr/ConfigCubemxProject.py
@@ -164,20 +164,6 @@ def get_git_head(path):
     return result.stdout.strip()
 
 
-def get_submodule_gitlink(project_dir, rel_path):
-    result = subprocess.run(
-        ["git", "-C", project_dir, "ls-tree", "HEAD", "--", rel_path],
-        capture_output=True,
-        text=True
-    )
-    if result.returncode != 0:
-        return ""
-    parts = result.stdout.strip().split()
-    if len(parts) >= 3 and parts[0] == "160000" and parts[1] == "commit":
-        return parts[2]
-    return ""
-
-
 def is_commit_ancestor(repo_path, older_commit, newer_commit):
     if not older_commit or not newer_commit:
         return False
@@ -309,7 +295,6 @@ def add_libxr(project_dir, libxr_commit=None, git_base="https://github.com",
     if os.path.exists(libxr_path):
         logging.info("LibXR submodule path exists.")
         current_commit = get_git_head(libxr_path)
-        project_commit = get_submodule_gitlink(project_dir, sub_rel_path_posix)
         dirty = not is_git_clean(libxr_path)
         fetched = False
         target_commit = ""
@@ -322,21 +307,17 @@ def add_libxr(project_dir, libxr_commit=None, git_base="https://github.com",
             logging.info(f"Initializing new LibXR submodule to default commit {target_commit}")
         elif dirty:
             logging.warning("LibXR submodule has local changes; keeping current checkout.")
-        elif (project_commit and default_libxr_commit and project_commit != default_libxr_commit
-              and current_commit in (project_commit, default_libxr_commit)):
+        elif default_libxr_commit and current_commit != default_libxr_commit:
             run_command(["git", "-C", libxr_path, "fetch", "origin"], ignore_error=True)
             fetched = True
 
-            if current_commit == project_commit and is_commit_ancestor(
-                libxr_path, project_commit, default_libxr_commit
-            ):
+            if is_commit_ancestor(libxr_path, current_commit, default_libxr_commit):
                 target_commit = default_libxr_commit
-                logging.info(f"Updating LibXR from older project commit to default {target_commit}")
-            elif current_commit == default_libxr_commit and not is_commit_ancestor(
-                libxr_path, project_commit, default_libxr_commit
-            ):
-                target_commit = project_commit
-                logging.info(f"Restoring LibXR to project submodule commit {target_commit}")
+                logging.info(f"Updating clean LibXR checkout to package default {target_commit}")
+            elif is_commit_ancestor(libxr_path, default_libxr_commit, current_commit):
+                logging.info("LibXR checkout is newer than the package default; keeping it.")
+            else:
+                logging.info("LibXR checkout has diverged from the package default; keeping it.")
 
         if target_commit:
             if not fetched:


### PR DESCRIPTION
## Summary
- update clean LibXR checkouts that are ancestors of the package default commit
- preserve current, newer, divergent, and dirty checkouts
- add real Git submodule policy smoke coverage and bump the package version to 5.2.4

## Verification
- push CI passed on Linux and Windows
- Python compatibility checks passed
- all STM32 target jobs passed
- local wheel build and isolated install passed

## Summary by Sourcery

调整 LibXR 子模块更新行为，仅刷新相对于包默认提交而言已过期的、干净的检出，并记录更新后的策略。

新特性：
- 添加 LibXR 子模块策略冒烟测试脚本，用于在以下场景中验证行为：过期、当前、更高版本、发生分歧、工作区脏以及显式提交。

增强：
- 简化 LibXR 子模块处理逻辑，仅依赖提交的祖先关系，而不再使用记录在项目中的 gitlink。
- 明确 README 中关于 LibXR 子模块提交选择的文档，以及在省略 `--commit` 时的默认升级行为。

构建：
- 将 libxr 包版本提升到 5.2.4。

CI：
- 扩展 Python 包发布工作流以运行 LibXR 子模块策略冒烟检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust LibXR submodule update behavior to refresh only stale clean checkouts relative to the package default commit and document the updated policy.

New Features:
- Add a LibXR submodule policy smoke test script that validates behavior across stale, current, newer, divergent, dirty, and explicit commit scenarios.

Enhancements:
- Simplify LibXR submodule handling logic by relying solely on commit ancestry instead of the recorded project gitlink.
- Clarify README documentation for LibXR submodule commit selection and default upgrade behavior when `--commit` is omitted.

Build:
- Bump the libxr package version to 5.2.4.

CI:
- Extend the Python package publish workflow to run the LibXR submodule policy smoke checks.

</details>